### PR TITLE
Add Partial Fix for Linux Render Issues, Add Simulator Run Script, and Update Docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,12 @@ __pycache__/
 *.py[cod]
 *$py.class
 
+# vim files
+*.swp
+
+# ignore generated datafile
+*.npy
+
 # C extensions
 *.so
 

--- a/README.md
+++ b/README.md
@@ -29,5 +29,15 @@ Though, these are included in the setup.py file.  For the absolutely correct lis
 There are a variety of examples in the 'examples' folder.  Check these out before
 starting your simulation!
 
+You can run the examples with
+```
+./run_sim.py rps/examples/<example_name>.py
+```
+
+You can also run the examples without the wrapper, but it won't perform any dependnecy sanity checks.
+```
+python3 rps/examples/<example_name>.py
+```
+
 # Submission Instructions
 When your simulation is complete, go the the Robotarium [website](https://www.robotarium.org), follow the instructions there, and see your code run on real robots!

--- a/rps/examples/formation_control.py
+++ b/rps/examples/formation_control.py
@@ -33,7 +33,7 @@ weights = np.array([
 iterations = 2000
 N = 6
 
-r = robotarium.Robotairum(number_of_agents=N, number_of_agents=10, show_figure=True, save_data=True, update_time=1)
+r = robotarium.Robotarium(number_of_agents=N, show_figure=True, save_data=True, update_time=1)
 
 si_barrier_cert = create_single_integrator_barrier_certificate(N)
 

--- a/run_sim.py
+++ b/run_sim.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+
+import os
+import sys
+
+# PyQt4 still has a bug where it fails to yeild interactive control
+# back to the starting terminal on some operating systems. This is
+# at least observed on Linux and may affect OSX as well. Manually
+# setting Qt4 return hooks didn't work. The only apparent fix
+# is to move to Qt5 if able. This method check if the required
+# PyQt5 modules and backend are present. If they are, we move the
+# renderer forward to PyQt5. Otherwise, we fallback to the default.
+#
+# Backend *MUST* be set before any subpackages are imported. 
+def select_pyplot_renderer():
+	try:
+		from PyQt5 import QtCore, QtGui, QtWidgets
+		import matplotlib
+		matplotlib.use('Qt5Agg')
+	except ImportError:
+		if sys.platform == "linux" or sys.platform == "linux2":
+			print('*** could not set sim renderer to Qt5Agg')
+			print('*** canvas may fail to yield interactive control on close')
+			print('*** please install PyQt5 if you experience issues')
+			print('\tDebian Package: python3-pyqt5')
+			print('\tFedora Core: python3-qt5')
+			print('')
+			print('')
+
+		# fallback renderer
+		import matplotlib
+		matplotlib.use('TkAgg')
+	
+
+select_pyplot_renderer()
+
+print('launching sim program: ' + sys.argv[1])
+print('')
+os.system('python3 ' + sys.argv[1])
+exit(0)
+


### PR DESCRIPTION
On some Linux DEs PyQt4 still doesn't release input hooks properly. The call to manually restore them has no effect. This causes isolated issues for some users that are particularly painful if they aren't able to force refresh the DE. I had trouble with this on 18.04, i3, in a VM. The fix is to search for PyQt5 availability and manually set it as the renderer (although this usually isn't necessary) if available. Linux users without this option should receive a warning. The render backend must be set before any of the submodules are imported.

This patch will force PyQt5 renderer if available and will warn only Linux users if they aren't on PyQt5. It suggests packages for Debian and Fedora if the warning is displayed. To address the issue of setting the backend before import, a run script has been added that ensures the change is made before import dependencies are evaluated. Combined with the documentation, it also makes the sim a little friendlier to use for new folks.