### PR TITLE
Support for Matplotlib 3.7.3+

### DIFF
--- a/rps/robotarium_abc.py
+++ b/rps/robotarium_abc.py
@@ -80,7 +80,7 @@ class RobotariumABC(ABC):
             for i in range(number_of_robots):
                 # p = patches.RegularPolygon((self.poses[:2, i]), 4, math.sqrt(2)*self.robot_radius, self.poses[2,i]+math.pi/4, facecolor='#FFD700', edgecolor = 'k')
                 p = patches.Rectangle((self.poses[:2, i]+self.robot_length/2*np.array((np.cos(self.poses[2, i]+math.pi/2), np.sin(self.poses[2, i]+math.pi/2)))+\
-                                                0.04*np.array((-np.sin(self.poses[2, i]+math.pi/2), np.cos(self.poses[2, i]+math.pi/2)))), self.robot_length, self.robot_width, (self.poses[2, i] + math.pi/4) * 180/math.pi, facecolor='#FFD700', edgecolor='k')
+                                                0.04*np.array((-np.sin(self.poses[2, i]+math.pi/2), np.cos(self.poses[2, i]+math.pi/2)))), self.robot_length, self.robot_width, angle=(self.poses[2, i] + math.pi/4) * 180/math.pi, facecolor='#FFD700', edgecolor='k')
 
                 rled = patches.Circle(self.poses[:2, i]+0.75*self.robot_length/2*np.array((np.cos(self.poses[2, i]), np.sin(self.poses[2, i]))+0.04*np.array((-np.sin(self.poses[2, i]+math.pi/2), np.cos(self.poses[2, i]+math.pi/2)))),
                                        self.robot_length/2/5, fill=False)


### PR DESCRIPTION
Tested locally for updated support of Matplotlib 3.7.3+ with `patches.Rectangle()` now requiring `angle=` as an input argument. This change also works with previous versions of Matplotlib (tested from 3.6.0+)

Current:
`patches.Rectangle((x,y), width, length, angle, **kwargs)`

> TypeError: Rectangle.__init__() takes 4 positional arguments but 5 were given

Update:
`patches.Rectangle((x,y), width, length, angle=angle, **kwargs)`