### PR TITLE
Update uni_go_to_pose_clf.py

### DIFF
--- a/rps/examples/go_to_pose/uni_go_to_pose_clf.py
+++ b/rps/examples/go_to_pose/uni_go_to_pose_clf.py
@@ -9,7 +9,7 @@ import time
 
 # Instantiate Robotarium object
 N = 5
-initial_conditions = np.array(np.mat('1 0.5 -0.5 0 0.28; 0.8 -0.3 -0.75 0.1 0.34; 0 0 0 0 0'))
+initial_conditions = np.array(np.asmatrix('1 0.5 -0.5 0 0.28; 0.8 -0.3 -0.75 0.1 0.34; 0 0 0 0 0'))
 r = robotarium.Robotarium(number_of_robots=N, show_figure=True, initial_conditions=initial_conditions,sim_in_real_time=True)
 
 # Define goal points by removing orientation from poses


### PR DESCRIPTION
Before the suggested change, NumPy produces the following error message:

AttributeError: `np.mat` was removed in the NumPy 2.0 release. Use `np.asmatrix` instead.

After the suggested change, the script runs as expected.