### PR TITLE
Update robotarium_abc.py

### DIFF
--- a/rps/robotarium_abc.py
+++ b/rps/robotarium_abc.py
@@ -80,7 +80,7 @@ class RobotariumABC(ABC):
                 # p = patches.RegularPolygon((self.poses[:2, i]), 4, math.sqrt(2)*self.robot_radius, self.poses[2,i]+math.pi/4, facecolor='#FFD700', edgecolor = 'k')
                 p = patches.Rectangle((self.poses[:2, i]+self.robot_length/2*np.array((np.cos(self.poses[2, i]+math.pi/2), np.sin(self.poses[2, i]+math.pi/2)))+\
                                                 0.04*np.array((-np.sin(self.poses[2, i]+math.pi/2), np.cos(self.poses[2, i]+math.pi/2)))), self.robot_length, self.robot_width, angle=(self.poses[2, i] + math.pi/4) * 180/math.pi, facecolor='#FFD700', edgecolor='k')
-
+                p.angle = (self.poses[2, i] - math.pi/2) * 180/math.pi
                 rled = patches.Circle(self.poses[:2, i]+0.75*self.robot_length/2*np.array((np.cos(self.poses[2, i]), np.sin(self.poses[2, i]))+0.04*np.array((-np.sin(self.poses[2, i]+math.pi/2), np.cos(self.poses[2, i]+math.pi/2)))),
                                        self.robot_length/2/5, fill=False)
                 lled = patches.Circle(self.poses[:2, i]+0.75*self.robot_length/2*np.array((np.cos(self.poses[2, i]), np.sin(self.poses[2, i]))+\


### PR DESCRIPTION
Previously, the robot body patch was drawn in the wrong orientation by the `__init__` method. Back-porting a line from the file `robotarium.py` solves this.

This improves the situation in Issue #24 considerably, but there is still a little left to do on that one. More comments over there.